### PR TITLE
networking.k8s.io/v1beta1 is deprecated. Updating

### DIFF
--- a/nuke_from_orbit/utils/templates/loadtest-ingress.yaml
+++ b/nuke_from_orbit/utils/templates/loadtest-ingress.yaml
@@ -1,41 +1,54 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1 
 kind: Ingress
 metadata:
   name: loadtest-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: {{loadtest_name}}
     networking.gke.io/managed-certificates: loadtest-cert
+    kubernetes.io/ingress.class: "gce"
 spec:
   rules:
     - host: locust.{{loadtest_dns_domain}}
       http:
         paths:
           - path: /*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: lm-pod
-              servicePort: 80
+              service:
+                name: lm-pod
+                port: 
+                  number: 80
     {% if external -%}
     - host: locust-metrics.{{loadtest_dns_domain}}
       http:
         paths:
           - path: /*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: le-pod
-              servicePort: 80
+              service:
+                name: lm-pod
+                port: 
+                  number: 80
     {% else -%}
     - host: prometheus.{{loadtest_dns_domain}}
       http:
         paths:
           - path: /*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: prom-pod
-              servicePort: 80
+              service:
+                name: prom-pod
+                port: 
+                  number: 80
     - host: grafana.{{loadtest_dns_domain}}
       http:
         paths:
           - path: /*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: grafana
-              servicePort: 80
+              service:
+                name: grafana
+                port: 
+                  number: 80
     {% endif %}


### PR DESCRIPTION
Per Kubernetes documentation: 

https://kubernetes.io/docs/reference/using-api/deprecation-guide/

The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.

Migrate manifests and API clients to use the networking.k8s.io/v1 API version, available since v1.19.
All existing persisted objects are accessible via the new API
Notable changes:
spec.backend is renamed to spec.defaultBackend
The backend serviceName field is renamed to service.name
Numeric backend servicePort fields are renamed to service.port.number
String backend servicePort fields are renamed to service.port.name
pathType is now required for each specified path. Options are Prefix, Exact, and ImplementationSpecific. To match the undefined v1beta1 behavior, use ImplementationSpecific.
